### PR TITLE
Added git version to footer when logged in

### DIFF
--- a/d120/settings.py
+++ b/d120/settings.py
@@ -65,6 +65,7 @@ INSTALLED_APPS = (
     'd120',
     'pyTUID',
     'pyBuchaktion',
+    'git_version',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/d120/templates/footer.html
+++ b/d120/templates/footer.html
@@ -1,3 +1,4 @@
+{% load git_tags %}
 <footer class="footer">
     <div class="container">
         <div class="row">
@@ -16,8 +17,9 @@
                 <p><a href="https://twitter.com/d120de" aria-label="Twitter"><i class="fa fa-fw fa-twitter" aria-hidden="true" title="Twitter"></i></a></p>
                 <p><a href="https://github.com/d120" aria-label="Github"><i class="fa fa-fw fa-github" aria-hidden="true" title="Github"></i></a></p>
             </div>
-            <div class="col-md-4 bottom-align-text" id="copyright">
+            <div class="col-md-4 bottom-align-text" {% if not request.user.is_authenticated %}id="copyright"{% endif %}>
                 <p>&copy; Fachschaft Informatik TU Darmstadt</p>
+                {% if request.user.is_authenticated %}<p>Commit: {% current_commit_short '.' %}</p>{% endif %}
             </div>
         </div>
     </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ git+https://github.com/divio/djangocms-column               # install from sourc
 
 # own packages installed from git
 git+https://github.com/d120/pyBuchaktion@v1.2.0
+git+https://github.com/d120/django-git-version


### PR DESCRIPTION
This change uses [django-git-version](https://github.com/d120/django-git-version) to display the current djangocms commit hash when logged into admin as any user. This should help identifying which version is currently deployed, and whether a redeploy is needed or was successful.