### PR TITLE
Set session and csrf cookie names to be unique to the application

### DIFF
--- a/d120/settings.py
+++ b/d120/settings.py
@@ -233,3 +233,8 @@ CMS_RSS_PLUGIN_TEMPLATE = 'rss_feed.html'
 
 TUID_SERVER_URL = 'https://sso.tu-darmstadt.de/'
 TUID_FORCE_SERVICE_URL = 'https://localhost:8000/tuid/login/'
+
+# application-specific-cookies
+CSRF_COOKIE_NAME = 'djangocms_csrftoken'
+SESSION_COOKIE_NAME = 'djangocms_sessionid'
+


### PR DESCRIPTION
Since we host everything from one domain, the same cookie names are used and overwritten by every django application. This pr fixes this by prepending the cookie names with an identifier (djangocms)