### PR TITLE
Fix ToDo list storage error for multiple lists on a single page

### DIFF
--- a/d120/templates/plugins/todo_list.html
+++ b/d120/templates/plugins/todo_list.html
@@ -16,14 +16,7 @@
         let myStorage = window.localStorage;
 
         function update(event) {
-            let checked = form.querySelectorAll(':checked');
-            var isChecked = false;
-            checked.forEach(input => {
-                if (input == event.target) {
-                    isChecked = true;
-                }
-            });
-            myStorage.setItem(event.target.name, isChecked ? 'true' : 'false');
+            myStorage.setItem(event.target.name, event.target.checked ? 'true' : 'false');
         }
 
         for (var form of forms) {


### PR DESCRIPTION
Currently, the update method uses the last global value for form, hence works only for the last todo list on page (for todo items from all other lists, a state of "unchecked" will be assumed and updated in local storage. Loading is not affected and works correctly for multiple lists.

My change massively simplifies the update method and removes the need to know the form a todo item belongs to. Instead, it directly accesses the checked attribute of the event source and uses it to update local storage.