### PR TITLE
Quickfix for invisible map marker texts

### DIFF
--- a/d120/templates/plugins/map.html
+++ b/d120/templates/plugins/map.html
@@ -5,7 +5,7 @@
 
     <style>
         .olFramedCloudPopupContent {
-            overflow-y:scroll!important;
+            overflow-y:auto!important;
         }
     </style>
 

--- a/d120/templates/plugins/map.html
+++ b/d120/templates/plugins/map.html
@@ -2,6 +2,13 @@
 
 {% addtoblock "css" %}
     <link rel="stylesheet" type="text/css" href="{% static "d120/plugins/css/map.css" %}" />
+
+    <style>
+        .olFramedCloudPopupContent {
+            overflow-y:scroll!important;
+        }
+    </style>
+
 {% endaddtoblock %}
 
 {% addtoblock "js" %}


### PR DESCRIPTION
Currently, the bubble describing a marker is set to overflow:hidden by OpenLayers. This might result in longer text being not visible due to the quite small max size of the bubble. With this quickfix, it is ensured that there is always a vertical scrollbar to access this text.