### PR TITLE
Cleanup TUID+Buchaktion comments; remove django-import-export

### DIFF
--- a/d120/settings.py
+++ b/d120/settings.py
@@ -58,7 +58,6 @@ INSTALLED_APPS = (
     'djangocms_inherit',
     'djangocms_redirect',
     'djangocms_history',
-#    'aldryn_bootstrap3',
     'djangocms_icon',
     'djangocms_link',
     'djangocms_picture',
@@ -81,11 +80,7 @@ INSTALLED_APPS = (
     'djangocms_bootstrap4.contrib.bootstrap4_utilities',
     'rssplugin',
     'sslserver',
-    'import_export',
-#    'bootstrap3',
     'd120',
-#    'pyTUID',
-#    'pyBuchaktion',
     'git_version',
     'cmsplugin_cascade',
     'cmsplugin_cascade.clipboard',  # optional
@@ -111,7 +106,6 @@ MIDDLEWARE = [
     'cms.middleware.language.LanguageCookieMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
-#    'pyTUID.middleware.TUIDMiddleware',
 ]
 
 TEMPLATES = [
@@ -256,13 +250,6 @@ FILER_ALLOW_REGULAR_USERS_TO_ADD_ROOT_FOLDERS = True
 ### RSSPLUGIN ###
 
 CMS_RSS_PLUGIN_TEMPLATE = 'rss_feed.html'
-
-
-### PYTUID ###
-
-TUID_SERVER_URL = 'https://sso.tu-darmstadt.de/'
-TUID_FORCE_SERVICE_URL = 'https://localhost:8000/tuid/login/'
-
 
 ### CASCADE ###
 

--- a/d120/settings_production.py
+++ b/d120/settings_production.py
@@ -98,9 +98,3 @@ EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 EMAIL_HOST_USER = 'djangocms'
 EMAIL_HOST_PASSWORD = secrets.MAIL_PASSWORD
-
-
-### PYTUID ###
-
-TUID_SERVER_URL = 'https://sso.tu-darmstadt.de'
-TUID_FORCE_SERVICE_URL = 'https://www.fachschaft.informatik.tu-darmstadt.de/tuid/login/'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ django-cms==3.7.4
 
 # a bunch of packages installed without regarding their versions
 # when (temporary) pinning of versions is necessary, comment on the reasoning
-django-import-export==2.3.0
 djangocms-bootstrap4==2.0.0
 # cmsplugin-filer
 djangocms-history==2.0.0


### PR DESCRIPTION
As `dependabot` suggest in #30 to upgrade `django-import-export` to a newer version, but that was only included for `pyBuchaktion` in the first place, this PR removes that along with the remaining settings and comments related to:

* `pyBuchation`
* `pyTUID`
* `bootstrap3`
* `import_export`