### PR TITLE
Remove djangocms-inherit

### DIFF
--- a/d120/settings.py
+++ b/d120/settings.py
@@ -55,7 +55,6 @@ INSTALLED_APPS = (
     'cmsplugin_filer_teaser',
     'cmsplugin_filer_utils',
     'cmsplugin_filer_video',
-    'djangocms_inherit',
     'djangocms_redirect',
     'djangocms_history',
     'djangocms_icon',

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,4 @@ django-git-version==0.1.0
 
 #git+https://github.com/divio/djangocms-attributes-field
 git+https://github.com/andersinno/django-rss-plugin            # install from source until PyPi release is up to date
-
-git+https://github.com/isotoma/djangocms-inherit
 git+https://github.com/pawelmarkowski/cmsplugin-filer


### PR DESCRIPTION
`djangocms-inherit` allows the user to include all plugins from another page as a plugin in the current page. This may be useful, but the library:

* is not really maintained anymore
* is not published to pypi (and thus re-downloaded with every update)
* produces warnings in the console
* is likely not compatible with an update to django 3.x
* is not currently used on our site as per `./manage.py cms list plugins`

This PR proposes to remove that plugin