### PR TITLE
Freeze django-filer to 2.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,13 +6,13 @@ django-cms==3.8.0
 # a bunch of packages installed without regarding their versions
 # when (temporary) pinning of versions is necessary, comment on the reasoning
 djangocms-bootstrap4==2.0.0
-# cmsplugin-filer
 djangocms-history==2.0.0
 djangocms-link==3.0.0
 djangocms-redirect==0.5.0
 djangocms-style==3.0.0
 djangocms-text-ckeditor==4.0.0
 djangocms-column==1.11.0
+django-filer=2.0.2
 django-auth-ldap==2.2.0
 django-redis==4.12.1
 django-select2==7.4.2


### PR DESCRIPTION
If we explicitly mention django-filer in the `requirements.txt`, we can get a ping from dependabot in case that changes while we prepare #52 and #55.