### PR TITLE
Remove language cookie

### DIFF
--- a/d120/settings.py
+++ b/d120/settings.py
@@ -102,7 +102,6 @@ MIDDLEWARE = [
     'cms.middleware.user.CurrentUserMiddleware',
     'cms.middleware.page.CurrentPageMiddleware',
     'cms.middleware.toolbar.ToolbarMiddleware',
-    'cms.middleware.language.LanguageCookieMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
 ]


### PR DESCRIPTION
Since we do not have a cookie banner and, except the language cookie, do not set cookies on our main pages, I would suggest to just drop the language cookie all together.

This means that subsequent visits to the site will switch back to the language preferred by the browser, which is sufficient for most people imo.