### PR TITLE
Upgrade to fontsource 4

### DIFF
--- a/d120/settings.py
+++ b/d120/settings.py
@@ -263,7 +263,7 @@ CKEDITOR_SETTINGS = {
     'contentsCss': [
         '/static/vendor/bootstrap/dist/css/bootstrap.min.css',
         '/static/vendor/font-awesome/css/font-awesome.min.css',
-        '/static/vendor/fontsource-libre-franklin/index.css',
+        '/static/vendor/@fontsource/libre-franklin/index.css',
         '/static/d120/css/custom.css',
     ],
 }

--- a/d120/templates/base.html
+++ b/d120/templates/base.html
@@ -15,7 +15,7 @@
         {% addtoblock "css" %}
         <link rel="stylesheet" type="text/css" href="{% static 'vendor/bootstrap/dist/css/bootstrap.min.css' %}" />
         <link rel="stylesheet" type="text/css" href="{% static 'vendor/font-awesome/css/font-awesome.min.css' %}" />
-        <link rel="stylesheet" type="text/css" href="{% static 'vendor/fontsource-libre-franklin/index.css' %}" />
+        <link rel="stylesheet" type="text/css" href="{% static 'vendor/@fontsource/libre-franklin/index.css' %}" />
         <link rel="stylesheet" type="text/css" href="{% static 'd120/css/custom.css' %}" />
         <style>
             a, footer a:hover, .sidebar-nav a, .sidebar-nav a:hover {

--- a/d120/templates/plain.html
+++ b/d120/templates/plain.html
@@ -15,7 +15,7 @@
         {% addtoblock "css" %}
         <link rel="stylesheet" type="text/css" href="{% static 'vendor/bootstrap/dist/css/bootstrap.min.css' %}" />
         <link rel="stylesheet" type="text/css" href="{% static 'vendor/font-awesome/css/font-awesome.min.css' %}" />
-        <link rel="stylesheet" type="text/css" href="{% static 'vendor/fontsource-libre-franklin/index.css' %}" />
+        <link rel="stylesheet" type="text/css" href="{% static 'vendor/@fontsource/libre-franklin/index.css' %}" />
         <link rel="stylesheet" type="text/css" href="{% static 'd120/css/custom.css' %}" />
         {% endaddtoblock %}
         {% render_block "css" %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,16 @@
       "name": "d120-djangocms",
       "license": "UNLICENSED",
       "dependencies": {
+        "@fontsource/libre-franklin": "^4.5.0",
         "bootstrap": "^4.5.3",
         "font-awesome": "^4.7.0",
-        "fontsource-libre-franklin": "^3.1.6",
         "jquery": "^3.6.0"
       }
+    },
+    "node_modules/@fontsource/libre-franklin": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/libre-franklin/-/libre-franklin-4.5.0.tgz",
+      "integrity": "sha512-pFJyUqbnQhuyyOa84GoAqZacRp4CTaZehBWD5/g8TaJXzmV3uKJpDczfYafE+UnMKKW60RLNx0NCucrDMnn3Zg=="
     },
     "node_modules/bootstrap": {
       "version": "4.5.3",
@@ -34,12 +39,6 @@
         "node": ">=0.10.3"
       }
     },
-    "node_modules/fontsource-libre-franklin": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/fontsource-libre-franklin/-/fontsource-libre-franklin-3.1.6.tgz",
-      "integrity": "sha512-KTPzeKQstZxKsiqDO+HSVo2GxmGWkC2Q98/9bcO1J98Zj/jFT40ON1PVODXSpJMSOn4rcctC8SglUN7xypzeJQ==",
-      "deprecated": "Package relocated. Please install and migrate to @fontsource/libre-franklin."
-    },
     "node_modules/jquery": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
@@ -47,6 +46,11 @@
     }
   },
   "dependencies": {
+    "@fontsource/libre-franklin": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/libre-franklin/-/libre-franklin-4.5.0.tgz",
+      "integrity": "sha512-pFJyUqbnQhuyyOa84GoAqZacRp4CTaZehBWD5/g8TaJXzmV3uKJpDczfYafE+UnMKKW60RLNx0NCucrDMnn3Zg=="
+    },
     "bootstrap": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.3.tgz",
@@ -57,11 +61,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
       "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
-    },
-    "fontsource-libre-franklin": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/fontsource-libre-franklin/-/fontsource-libre-franklin-3.1.6.tgz",
-      "integrity": "sha512-KTPzeKQstZxKsiqDO+HSVo2GxmGWkC2Q98/9bcO1J98Zj/jFT40ON1PVODXSpJMSOn4rcctC8SglUN7xypzeJQ=="
     },
     "jquery": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "license": "UNLICENSED",
   "private": true,
   "dependencies": {
+    "@fontsource/libre-franklin": "^4.5.0",
     "bootstrap": "^4.5.3",
     "font-awesome": "^4.7.0",
-    "fontsource-libre-franklin": "^3.1.6",
     "jquery": "^3.6.0"
   }
 }


### PR DESCRIPTION
Fontsource 4 uses new package naming schemes: instead of `fontsource-libre-franklin` we need `@fontsource/libre-franklin`