### PR TITLE
Update Django to 2.2.27

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # major packages where new versions might introduce incompatibilities
 # test new major versions and update this file accordingly
-Django==2.2.26
+Django==2.2.27
 django-cms==3.8.0
 
 # a bunch of packages installed without regarding their versions


### PR DESCRIPTION
Django 2.2.27 fixes two security issues with severity “medium” in
2.2.26.

See: https://docs.djangoproject.com/en/dev/releases/2.2.27/